### PR TITLE
[3주차-큐] 문제7 - 손수빈

### DIFF
--- a/3주차) 큐/q07/merryfraise.js
+++ b/3주차) 큐/q07/merryfraise.js
@@ -1,0 +1,43 @@
+/**
+ * LeetCode
+ * https://leetcode.com/problemset/all
+ * Problem Number: 950
+ * Level: Medium
+ * Algorithm: Array / Queue / Sorting / Simulation
+ */
+
+/**
+ * @param {number[]} deck
+ * @return {number[]}
+ */
+
+/* pseudocode
+   1. 요구사항은 함수를 거쳐 나온 배열이 맨 위의 카드를 뽑고,
+      그 다음 카드를 맨 뒤로 보내는 과정을 거쳤을 때 오름차순이 되도록 만들어라
+   2. 이 과정을 반대로 하면 맨 뒤의 카드를 맨 앞으로 가져오고, (pop and unshift)
+      뽑은 카드를 다시 맨 위로 배치시키면 됨 (unshift)
+*/
+
+var deckRevealedIncreasing = function (deck) {
+  const result = [];
+
+  // deck을 모든 과정을 거쳐 오름차순이 된 배열으로 가정
+  deck.sort((a, b) => a - b);
+
+  while (deck.length > 0) {
+    const popFromDeck = deck.pop();
+
+    // result에 아무 요소도 없다면 unshift가 아니라 push 진행
+    if (!result.length) result.push(popFromDeck);
+    else {
+      // deck에 남은 카드 존재 여부와 상관 없이 result에서는 항상 unshift가 발생
+      result.unshift(popFromDeck);
+
+      /* deck에 요소가 존재한다면 result에서는 맨 뒤의 카드를 맨 앞으로 가져오는 과정이 필요
+         (pop and unshift) */
+      if (deck.length) result.unshift(result.pop());
+    }
+  }
+
+  return result;
+};


### PR DESCRIPTION
### 문제 설명&링크
* 문제 이름: LeetCode medium. < Reveal Cards In Increasing Order > 
* 문제 링크: https://leetcode.com/problems/reveal-cards-in-increasing-order/description/

### 의사 코드
1. 요구사항은 함수를 거쳐 나온 배열이 맨 위의 카드를 뽑고,
   그 다음 카드를 맨 뒤로 보내는 과정을 거쳤을 때 오름차순이 되도록 만들어라
2. 이 과정을 반대로 하면 맨 뒤의 카드를 맨 앞으로 가져오고, (pop and unshift)
   뽑은 카드를 다시 맨 위로 배치시키면 됨 (unshift)

### 코드
```js
/**
 * @param {number[]} deck
 * @return {number[]}
 */

var deckRevealedIncreasing = function (deck) {
  const result = [];

  // deck을 모든 과정을 거쳐 오름차순이 된 배열으로 가정
  deck.sort((a, b) => a - b);

  while (deck.length > 0) {
    const popFromDeck = deck.pop();

    // result에 아무 요소도 없다면 unshift가 아니라 push 진행
    if (!result.length) result.push(popFromDeck);
    else {
      // deck에 남은 카드 존재 여부와 상관 없이 result에서는 항상 unshift가 발생
      result.unshift(popFromDeck);

      /* deck에 요소가 존재한다면 result에서는 맨 뒤의 카드를 맨 앞으로 가져오는 과정이 필요
         (pop and unshift) */
      if (deck.length) result.unshift(result.pop());
    }
  }

  return result;
};
```

### 느낀점&어려웠던 점
**그** 문제입니다...
발표 덕분에 문제 요구사항 자체는 이해했지만 직접 풀어보지 않으면 과정이 이해가 가지 않을 것 같아서 풀었어요.
한 가지 궁금한건... 함수를 통해 특정 조건을 만족하도록 정렬된 이 배열이 그 조건을 거치는 과정은 큐가 맞는데, 이걸 역순으로 진행하는 건 큐가 아닌 것 같아서.. 큐로 풀려면 어떻게 푸는게 맞는 것인가 고민하게 됩니다 🤔 (`pop`한 뒤 `unshift`하는 건 아무래도 스택도 큐도 아닌 편이지요)