### PR TITLE
[3주차-큐] 문제9 - 신나현

### DIFF
--- a/3주차) 큐/q09/shinnh2.js
+++ b/3주차) 큐/q09/shinnh2.js
@@ -1,0 +1,28 @@
+let [n, k] = require("fs")
+	.readFileSync("./1158.txt")
+	.toString()
+	.trim()
+	.split(" "); // ./1158.txt /dev/stdin
+
+//의사코드
+/*
+  0. 1부터 인원수까지를 담음 배열 circle, 
+    제거된 사람이 순서대로 담긴 큐 ys, 
+    제거될 순서 i(초기값은 0)
+  1. circle에서 제거될 사람의 순서는 
+    i=(이전i-1+input[1])%현재 circle의 길이
+  2. circle[i]번째 값을 ys에 넣는다.
+  3. circle에서 circle[i]를 삭제한다.
+  4. 1~3을 circle의 길이가 0이 될 때까지 반복한다.
+*/
+let circle = Array.from({ length: +n }, (v, i) => i + 1);
+k = +k;
+let ys = [];
+let i = 0;
+
+while (circle.length > 0) {
+	i = (i - 1 + k) % circle.length;
+	ys.push(circle[i]);
+	circle.splice(i, 1);
+}
+console.log(`<${ys.join(", ")}>`);


### PR DESCRIPTION
### 문제 설명&링크
* 문제 이름: 백준 1158 <요세푸스 문제> 
* 문제 링크: https://www.acmicpc.net/problem/1158

### 의사 코드
0. 1부터 인원수까지를 담을 배열 circle, 
  제거된 사람이 순서대로 담긴 배열  ys, 
  제거될 순서 i(초기값은 0)
1. circle에서 제거될 사람의 순서는 
  i=(이전i-1+input[1])%현재 circle의 길이 
 이다.
2. circle[i]번째 값을 ys에 넣는다.
3. circle에서 circle[i]를 삭제한다.
4. 1~3을 circle의 길이가 0이 될 때까지 반복한다.

### 코드
```js
let [n, k] = require("fs")
	.readFileSync("/dev/stdin")
	.toString()
	.trim()
	.split(" ");

let circle = Array.from({ length: +n }, (v, i) => i + 1);
k = +k;
let ys = [];
let i = 0;

while (circle.length > 0) {
	i = (i - 1 + k) % circle.length;
	ys.push(circle[i]);
	circle.splice(i, 1);
}
console.log(`<${ys.join(", ")}>`);
```

### 느낀점&어려웠던 점
- 이번 문제의 핵심은 종이에 열심히 풀어보면서 구했던  "circle에서 제거될 사람의 순서는 ` i=(이전i-1+input[1])%현재 circle의 길이` "입니다. 공식으로 만들어놓고 뿌듯했던 기억이 납니다..!
- ys를 큐라고 생각하고 풀었는데, 따지고 보면 그냥 배열로 사용하고 큐는 아닌거 같네요..!
- 큐를 사용해서 푸는 방법이 있을지 좀 더 고민해보겠습니다...!