### PR TITLE
[4주차-완전탐색] 문제6 - 손수빈

### DIFF
--- a/4주차) 완전탐색/q06/merryfraise.js
+++ b/4주차) 완전탐색/q06/merryfraise.js
@@ -1,0 +1,39 @@
+/**
+ * BAEKJOON ONLINE JUDGE
+ * https://www.acmicpc.net/problem/4673
+ * Problem Number: 4673
+ * Level: Silver V
+ * Algorithm: 수학 / 구현 / 브루트포스 알고리즘
+ */
+
+/* pseudocode
+   1. 셀프 넘버가 아닌 수를 찾는 함수 findNotSelfNumber
+      자기 자신 + 자리수 별 숫자를 모두 더한 값은 셀프 넘버가 아님
+   2. 1부터 10000까지 숫자를 가진 해시 nums
+   3. notSelfNums에 1부터 10000까지 숫자를 대입하며 셀프 넘버가 아닌 숫자를 push
+   4. nums에서 notSelfNums에 해당하는 숫자들을 삭제하고 출력
+*/
+
+const findNotSelfNumber = (num) => {
+  const numSplit = String(num).split('');
+  let notSelfNumber = num;
+
+  for (const el of numSplit) {
+    notSelfNumber += +el;
+  }
+
+  return notSelfNumber;
+};
+
+const nums = new Set(Array.from({ length: 10000 }, (_, i) => i + 1));
+const notSelfNums = [];
+
+for (let i = 1; i <= 10000; i++) {
+  notSelfNums.push(findNotSelfNumber(i));
+}
+
+for (const el of notSelfNums) {
+  nums.delete(el);
+}
+
+console.log([...nums].join('\n'));


### PR DESCRIPTION
### 문제 설명&링크
* 문제 이름: 백준 silver5. <셀프 넘버> 
* 문제 링크: https://www.acmicpc.net/problem/4673

### 의사 코드
1. 셀프 넘버가 아닌 수를 찾는 함수 findNotSelfNumber
   자기 자신 + 자리수 별 숫자를 모두 더한 값은 셀프 넘버가 아님
2. 1부터 10000까지 숫자를 가진 해시 nums
3. notSelfNums에 1부터 10000까지 숫자를 대입하며 셀프 넘버가 아닌 숫자를 push
4. nums에서 notSelfNums에 해당하는 숫자들을 삭제하고 출력

### 코드
```js
const findNotSelfNumber = (num) => {
  const numSplit = String(num).split('');
  let notSelfNumber = num;

  for (const el of numSplit) {
    notSelfNumber += +el;
  }

  return notSelfNumber;
};

const nums = new Set(Array.from({ length: 10000 }, (_, i) => i + 1));
const notSelfNums = [];

for (let i = 1; i <= 10000; i++) {
  notSelfNums.push(findNotSelfNumber(i));
}

for (const el of notSelfNums) {
  nums.delete(el);
}

console.log([...nums].join('\n'));
```

### 느낀점&어려웠던 점
속도를 조금이라도 높여보고자 Set을 사용해봤습니다.

```js
for (const el of nums) {
  nums.delete(findNotSelfNumber(el));
}
```
원래는 이렇게 제거해주려고 했는데 이럴 경우
el = 1일 때 2를 삭제하게 되면서 그 다음 요소가 3이 되기 때문에
el = 3일 때 6을 삭제하고
el = 4인 경우가 남게 되더라구요 (4는 셀프 넘버가 아니기 때문에 ~2 + 2 = 4이므로~ `nums`에 남아있으면 안됩니다!)

그래서 셀프 넘버가 아닌 숫자들을 배열에 몰아넣고 소거하는 방법을 선택했습니다.