### PR TITLE
[6주차-BFS] 문제5 - 신나현

### DIFF
--- a/6주차) BFS/q05/shinnh2.js
+++ b/6주차) BFS/q05/shinnh2.js
@@ -1,0 +1,36 @@
+//의사코드
+/*
+0. 모든 가지수가 자신을 노드로, 왼쪽 자식은 2배수, 오른쪽 자식은 끝에 1을 더한 값이 되는, 힙 모양을 띠고 있다고 가정한다. (루트는 A)
+1. [자신의 값, depth] 형태로 노드를 생성해가며 값을 탐색한다. 해당 노드는 queue에 추가해가며 확인한다. 
+2. queue=[[A,1]], result는 -1로 선언한다.
+3. 아래의 과정을 queue가 빌 때까지 반복한다.
+  3.1. queue의 앞의 값을 제거하고 현재 노드 nowNode, 현재 깊이 depth로 할당한다.
+  3.2. 현재 노드가 b라면 result에 depth를 할당하고 반복문을 멈춘다.
+  3.3. 현재 노드가 b보다 작다면 자식노드를 생성한다.
+    queue.push([nowNode*2,depth+1])
+    queue.push([nowNode*2*10+1,depth+1]) 
+4. 3의 과정이 끝나면 result를 반환한다.
+*/
+
+let [A, B] = require("fs")
+	.readFileSync("./16953.txt")
+	.toString()
+	.replace(/\r/g, "")
+	.trim()
+	.split(" "); // ./16953.txt /dev/stdin
+B = +B;
+
+let queue = [[+A, 1]];
+let result = -1;
+while (queue.length) {
+	let [nowNode, depth] = queue.shift();
+	if (nowNode === B) {
+		result = depth;
+		break;
+	}
+	if (nowNode < B) {
+		queue.push([nowNode * 2, depth + 1]);
+		queue.push([nowNode * 10 + 1, depth + 1]);
+	}
+}
+console.log(result);


### PR DESCRIPTION
### 문제 설명&링크
* 문제 이름: 백준 - 16953 <A → B> 
* 문제 링크: https://www.acmicpc.net/problem/16953

### 의사 코드
0. 모든 가지수가 자신을 노드로, 왼쪽 자식은 2배수, 오른쪽 자식은 끝에 1을 더한 값이 되는, 힙 모양을 띠고 있다고 가정한다. (루트는 A)
1. [자신의 값, depth] 형태로 노드를 생성해가며 값을 탐색한다. 해당 노드는 queue에 추가해가며 확인한다. 
2. queue=[[A,1]], result는 -1로 선언한다.
3. 아래의 과정을 queue가 빌 때까지 반복한다.
  3.1. queue의 앞의 값을 제거하고 현재 노드 nowNode, 현재 깊이 depth로 할당한다.
  3.2. 현재 노드가 b라면 result에 depth를 할당하고 반복문을 멈춘다.
  3.3. 현재 노드가 b보다 작다면 자식노드를 생성한다.
    queue.push([nowNode*2,depth+1])
    queue.push([nowNode*2*10+1,depth+1]) 
4. 3의 과정이 끝나면 result를 반환한다.

### 코드
```js
let [A, B] = require("fs")
	.readFileSync("./16953.txt")
	.toString()
	.replace(/\r/g, "")
	.trim()
	.split(" "); // ./16953.txt /dev/stdin
B = +B;

let queue = [[+A, 1]];
let result = -1;
while (queue.length) {
	let [nowNode, depth] = queue.shift();
	if (nowNode === B) {
		result = depth;
		break;
	}
	if (nowNode < B) {
		queue.push([nowNode * 2, depth + 1]);
		queue.push([nowNode * 10 + 1, depth + 1]);
	}
}
console.log(result);
```

### 느낀점&어려웠던 점
- 요 몇 주 그래프, 힙, 탐색 등을 공부하면서 단순히 노드를 만들고, 탐색하는 것만 생각했습니다. 그런데 그러려니 노드를 반복해서 만들 때 반복문 탈출조건이 명확히 떠오르지 않았는데, 검색해보니 queue를 이용하면 된다는 힌트를 얻었습니다. 
- 노드나 그래프 등에 집착하기보다 효율적으로 너비 우선 탐색, 깊이 우선 탐색으로 풀어나가는 응용력이 필요하다는 생각이 들었어요. 이번 주의 개념에만 얽매이지 않고 이제까지 배운것들도 잘 응용해야겠습니다...!
