### PR TITLE
[6주차-DFS] 문제5 - 손수빈

### DIFF
--- a/6주차) DFS/q05/merryfraise.js
+++ b/6주차) DFS/q05/merryfraise.js
@@ -1,0 +1,59 @@
+/**
+ * BAEKJOON ONLINE JUDGE
+ * https://www.acmicpc.net/problem/2644
+ * Problem Number: 2644
+ * Level: Silver II
+ * Algorithm: 그래프 이론 / 그래프 탐색 / 너비 우선 탐색 / 깊이 우선 탐색
+ */
+
+const [N, question, M, ...input] = require('fs')
+  .readFileSync('/dev/stdin')
+  .toString()
+  .trim()
+  .split('\n')
+  .map((el) => (el.includes(' ') ? el.split(' ').map(Number) : +el));
+const [start, target] = question;
+
+/* pseudocode
+   1. 가족 관계를 기입해둔 family 배열
+   2. 방문 여부 체크를 위한 visited 배열
+      2-1. 방문했다면 방문한 인덱스의 visited를 1로 변경
+   3. 방문 순서 체크를 위한 stack
+      3-1. 가장 첫 방문은 start 노드
+      3-2. 현재 노드에서 갈 수 있는 경로들을 stack에 push
+      3-3. stack에서 pop한 노드가 바로 다음 방문할 곳
+   4. 현재 노드가 target 노드와 같다면 depth 출력
+*/
+
+const family = Array(N + 1)
+  .fill()
+  .map((_) => []);
+
+for (const el of input) {
+  family[el[0]].push(el[1]);
+  family[el[1]].push(el[0]);
+}
+
+const DFS = (start, target) => {
+  const visited = Array(N + 1).fill(0);
+
+  const stack = [[start, 0]];
+
+  while (stack.length) {
+    const [cur, depth] = stack.pop();
+
+    if (cur === target) return depth;
+
+    if (!visited[cur]) {
+      visited[cur] = 1;
+
+      for (const el of family[cur]) {
+        stack.push([el, depth + 1]);
+      }
+    }
+  }
+
+  return -1;
+};
+
+console.log(DFS(start, target));


### PR DESCRIPTION
### 문제 설명&링크
* 문제 이름: 백준 silver2. <촌수계산> 
* 문제 링크: https://www.acmicpc.net/problem/2644

### 의사 코드
1. 가족 관계를 기입해둔 family 배열
2. 방문 여부 체크를 위한 visited 배열
   2-1. 방문했다면 방문한 인덱스의 visited를 1로 변경
3. 방문 순서 체크를 위한 stack
   3-1. 가장 첫 방문은 start 노드
   3-2. 현재 노드에서 갈 수 있는 경로들을 stack에 push
   3-3. stack에서 pop한 노드가 바로 다음 방문할 곳
4. 현재 노드가 target 노드와 같다면 depth 출력

### 코드
```js
const [N, question, M, ...input] = require('fs')
  .readFileSync('/dev/stdin')
  .toString()
  .trim()
  .split('\n')
  .map((el) => (el.includes(' ') ? el.split(' ').map(Number) : +el));
const [start, target] = question;

const family = Array(N + 1)
  .fill()
  .map((_) => []);

for (const el of input) {
  family[el[0]].push(el[1]);
  family[el[1]].push(el[0]);
}

const DFS = (start, target) => {
  const visited = Array(N + 1).fill(0);

  const stack = [[start, 0]];

  while (stack.length) {
    const [cur, depth] = stack.pop();

    if (cur === target) return depth;

    if (!visited[cur]) {
      visited[cur] = 1;

      for (const el of family[cur]) {
        stack.push([el, depth + 1]);
      }
    }
  }

  return -1;
};

console.log(DFS(start, target));
```

### 느낀점&어려웠던 점
깊이 우선 탐색은 재귀만이 정답인 줄 알았는데, 검색해보니 BFS가 `queue`의 원리를 사용하는 것처럼 DFS는 `stack`의 원리를 이용한 것이라는 걸 알았습니다!
`queue`는 가장 앞의 요소를 선출하기 때문에 같은 `depth`에 있는 노드들을 먼저 탐색하는 것이고 `stack`은 가장 뒤의 요소를 선출하기 때문에 `depth`가 깊어지는 순서대로 탐색하는 거였습니다!

아무튼 결론은 그래서 `stack`을 사용해 DFS를 구현해보았습니다!