### PR TITLE
[6주차-DFS] 문제1 - 이희진

### DIFF
--- a/6주차) DFS/q01/9lumint.js
+++ b/6주차) DFS/q01/9lumint.js
@@ -1,0 +1,12 @@
+const hasPathSum = function (root, targetSum) {
+  if (!root) {
+    return false;
+  }
+  if (!root.left && !root.right && targetSum === root.val) {
+    return true;
+  }
+  return (
+    hasPathSum(root.left, targetSum - root.val) ||
+    hasPathSum(root.right, targetSum - root.val)
+  );
+};


### PR DESCRIPTION
### 문제 설명&링크
* 문제 이름: Leetcode Easy < Path Sum >
* 문제 링크: https://leetcode.com/problems/path-sum/

### 의사 코드
1. 목표 합계의 수에서 거친 노드의 값을 하나하나 빼면서 해당 트리로 목표 합계를 만들 수 있는지 확인한다.
2. 만약 목표 합계에 도달하지 못했음에도 더 이상 갈 수 있는 노드가 존재하지 않음 false를 반환한다.
3. 만약 더 이상 갈 노드가 없고 거쳤던 노드의 값들을 뺀 목표 합계의 나머지가 도착한 노드의 값과 일치하면 true를 반환한다.
4. 2와 3의 조건에 도달하기 전까지는 노드의 왼쪽과 오른쪽을 동시에 재귀를 이용해 탐색하며 위의 조건과 일치하는 노드가 있는지 탐색을 반복한다.

### 코드
```js
const hasPathSum = function (root, targetSum) {
  if (!root) {
    return false;
  }
  if (!root.left && !root.right && targetSum === root.val) {
    return true;
  }
  return (
    hasPathSum(root.left, targetSum - root.val) ||
    hasPathSum(root.right, targetSum - root.val)
  );
};
```

### 느낀점&어려웠던 점
목표 합계에서 도달한 노드의 값을 빼는 것까진 괜찮았는데 아직 조건에 도달하지 않았을 경우에 탐색을 어떻게 계속 이어가야 하는지 고민이 많아 많은 코드를 참고했었던 문제입니다. 분명 쉬운 난이도라고 했는데 ^^ 언제나 난이도에 뒷통수를 맞는 기분입니다. 간만의 재귀가 어색하지만 하도 반복해서 풀다 보니 조금은 익숙해진 것도 같네요. 물론 갈 길이 멀지만...