### PR TITLE
[6주차-BFS] 문제2 - 김진주

### DIFF
--- a/6주차) BFS/q02/jin123.js
+++ b/6주차) BFS/q02/jin123.js
@@ -1,0 +1,86 @@
+const fs = require("fs");
+const [V, ...info] = fs
+  .readFileSync("/dev/stdin")
+  .toString()
+  .trim()
+  .split("\n");
+class Node {
+  constructor(value) {
+    this.value = value;
+    this.next = null;
+  }
+}
+class Queue {
+  constructor() {
+    this.first = null;
+    this.last = null;
+    this.size = 0;
+  }
+  enqueue(val) {
+    let newNode = new Node(val);
+    if (!this.first) {
+      this.first = newNode;
+      this.last = newNode;
+    } else {
+      this.last.next = newNode;
+      this.last = newNode;
+    }
+    return ++this.size;
+  }
+  dequeue() {
+    if (!this.first) {
+      return null;
+    }
+    let temp = this.first;
+    if (this.first === this.last) {
+      this.last = null;
+    }
+    this.first = this.first.next;
+    this.size--;
+    return temp.value;
+  }
+}
+class Graph {
+  constructor() {
+    this.adjacencyList = {};
+  }
+  addVertex(vertex) {
+    if (!this.adjacencyList[vertex]) this.adjacencyList[vertex] = [];
+  }
+  addEdge(v1, v2) {
+    this.adjacencyList[v1].push(v2);
+  }
+  bfs(v, distance) {
+    const visited = [];
+    const queue = new Queue();
+    queue.enqueue(v);
+    visited[v] = true;
+
+    while (queue.size) {
+      const node = queue.dequeue();
+      this.adjacencyList[node].forEach((el) => {
+        if (!visited[el[0]]) {
+          queue.enqueue(el[0]);
+          visited[el[0]] = true;
+          distance[el[0]] = el[1] + distance[node];
+        }
+      });
+    }
+  }
+}
+const graph = new Graph();
+info.forEach((el) => {
+  const [key, ...edges] = el.split(" ").slice(0, -1);
+  graph.addVertex(+key);
+  for (let j = 0; j < edges.length; j += 2) {
+    graph.addEdge(+key, [+edges[j], +edges[j + 1]]);
+  }
+});
+const distance = Array(+V + 1).fill(0);
+graph.bfs(1, distance);
+let target = distance.reduce((acc, cur, i, arr) => {
+  return arr[acc] < cur ? i : acc;
+}, 1);
+distance.fill(0);
+graph.bfs(target, distance);
+console.log(Math.max(...distance));


### PR DESCRIPTION
### 문제 설명&링크
* 문제 이름: 백준 골드2 < 트리의 지름 >
* 문제 링크: https://www.acmicpc.net/problem/1167

### 의사 코드
1. 그래프를 생성하고 인접한 정점과 가중치를 담은 배열을 각 노드에 추가한다.
2. distance배열을 생성하고 값을 모두 0으로 초기화한다.
3. 그래프를 1번 시작정점으로 bfs한다.
4. distance를 이용하여 1번 정점에서 가장 거리가 먼 정점을 찾는다.
5. distance값을 0으로 초기화한다.
6. 5번에서 찾은 정점을 시작정점으로 bfs한다.
7. distance에서 가장 큰 값을 출력한다.

`bfs 매서드`

1. 방문 여부를 저장하는 배열 visited를 생성한다.
2. 방문한 노드에 인접한 정점을 저장할 큐 queue를 생성한다.
3. 시작 정점 v를 큐에 추가하고 visited에 v인덱스에 true를 할당한다.
4. 큐가 비어있을 때까지 다음을 반복한다.
    1. 큐에서 값을 꺼낸다.
    2. 꺼낸 값(A)에 대하여 인접한 정점들에 대하여 다음을 반복한다.
        1. 방문한 정점이 아니라면
            1. 큐에 정점을 추가한다.
            2. visited에 해당 정점 인덱스에 true를 할당한다.distance 의 해당 정점 인덱스에 시작 정점~A까지의 거리(=distance[A])+A에서 해당 정점까지의 거리를 할당한다.
  
`참고`

- 임의의 노드에서 가장 긴 경로로 연결돼 있는 노드는 트리의 지름에 해당하는 두 노드 중 하나라는 점으로 해결할 수 있습니다. 
- 그래프의 경우에는 어떤 한 정점에서 다른 정점까지의 경로가 여러 가지 일 수 있으므로 플로이드-와샬 알고리즘으로 찾을 수 있습니다. 
- 하지만 이 문제에서는 트리이므로 한 정점에서 다른 정점으로 가는 경로는 유일합니다. 탐색하다가 다른 정점을 만난다면 만난 정점으로의 경로는 이 경로가 유일하다는 것입니다. 그리고 간선의 개수를 더 많거나 작게 포함하는 경로도 존재하지 않습니다. 
- 따라서 distance를 결정할 때 다익스트라나 플로이드-와샬 알고리즘 처럼 다른 경로를 고려하지 않아도 됩니다.
- bfs로 distance에 각 정점으로의 거리가 얼마인지 저장하고 정점 중에서 가장 멀리 있는 정점이 지름에 해당하는 두 정점 중 하나입니다.
- 이렇게 찾은 정점에서 bfs로 각 노드에 대한 거리를 구하고 이 중 가장 큰 값이 지름이 됩니다.

### 코드
```js
const fs = require("fs");
const [V, ...info] = fs
  .readFileSync("/dev/stdin")
  .toString()
  .trim()
  .split("\n");
class Node {
  constructor(value) {
    this.value = value;
    this.next = null;
  }
}
class Queue {
  constructor() {
    this.first = null;
    this.last = null;
    this.size = 0;
  }
  enqueue(val) {
    let newNode = new Node(val);
    if (!this.first) {
      this.first = newNode;
      this.last = newNode;
    } else {
      this.last.next = newNode;
      this.last = newNode;
    }
    return ++this.size;
  }
  dequeue() {
    if (!this.first) {
      return null;
    }
    let temp = this.first;
    if (this.first === this.last) {
      this.last = null;
    }
    this.first = this.first.next;
    this.size--;
    return temp.value;
  }
}
class Graph {
  constructor() {
    this.adjacencyList = {};
  }
  addVertex(vertex) {
    if (!this.adjacencyList[vertex]) this.adjacencyList[vertex] = [];
  }
  addEdge(v1, v2) {
    this.adjacencyList[v1].push(v2);
  }
  bfs(v, distance) {
    const visited = [];
    const queue = new Queue();
    queue.enqueue(v);
    visited[v] = true;

    while (queue.size) {
      const node = queue.dequeue();
      this.adjacencyList[node].forEach((el) => {
        if (!visited[el[0]]) {
          queue.enqueue(el[0]);
          visited[el[0]] = true;
          distance[el[0]] = el[1] + distance[node];
        }
      });
    }
  }
}
const graph = new Graph();
info.forEach((el) => {
  const [key, ...edges] = el.split(" ").slice(0, -1);
  graph.addVertex(+key);
  for (let j = 0; j < edges.length; j += 2) {
    graph.addEdge(+key, [+edges[j], +edges[j + 1]]);
  }
});
const distance = Array(+V + 1).fill(0);
graph.bfs(1, distance);
let target = distance.reduce((acc, cur, i, arr) => {
  return arr[acc] < cur ? i : acc;
}, 1);
distance.fill(0);
graph.bfs(target, distance);
console.log(Math.max(...distance));

```

### 느낀점&어려웠던 점

- 문제를 bfs로 먼저 풀었는데 시간이 오래 걸렸습니다. 그래서 dfs로 풀어보니 훨씬 빨랐습니다! 특별히 dfs가 효율적인 문제는 아닌 것 같아서 bfs코드에서 큐를 배열에서 큐 클래스로 변경했는데 역시나 dfs랑 시간이 거의 비슷하게 나왔습니다. 정점 범위가 (2 ≤ V ≤ 100,000) 이 정도라서 확실히 shift 매서드가 심각하게 느려지는 것 같습니다.
- 임의의 노드에서 가장 긴 경로로 연결돼 있는 노드는 트리의 지름에 해당하는 두 노드 중 하나라는 점이 사실 직관적으로 이해하기가 좀 어려워서 고민을 좀 더 해보겠습니다... 