### PR TITLE
[6주차-DFS] 문제4 - 신나현

### DIFF
--- a/6주차) DFS/q04/shinnh2.js
+++ b/6주차) DFS/q04/shinnh2.js
@@ -1,0 +1,39 @@
+//의사코드
+/*
+0. 각 정점이 인덱스가 되고 값은 인접 정점들을 배열로가진 2차원 배열 adjacencyList를 만든다.
+1. 인접 정점 리스트 adjacencyList를 내림차순 정렬한다.
+2. 방문할 정점을 표시할 배열 visited를 정점 수만큼 생성한다.
+3. visited에 방문여부를 표시할 때 동시에 값으로 방문순서i를 표시해야 한다.
+4. 깊이우선탐색 재귀함수를 만들어 시작정점부터 실행한다. 
+	4.1. 아직 방문하지 않은 정점에 visited에 방문순서i를 증가시켜가며 표시하고,
+	4.2. 해당 정점의 인접 정점을 순회하며 visited를 활용해 아직 방문하지 않는 정점에 함수를 실행한다. 
+5. visited 배열을 알맞은 형태로 리턴한다.
+*/
+
+let [info, ...input] = require("fs")
+	.readFileSync("./dev/stdin")
+	.toString()
+	.trim()
+	.split("\n")
+	.map((el) => el.split(" ").map((el) => +el));
+let [N, M, R] = info;
+
+const adjacencyList = Array.from({ length: N + 1 }, (_) => []);
+for (let el of input) {
+	let [v1, v2] = el;
+	adjacencyList[v1].push(v2);
+	adjacencyList[v2].push(v1);
+}
+for (let i = 1; i < adjacencyList.length; i++) {
+	adjacencyList[i].sort((a, b) => b - a);
+}
+const visited = Array(N).fill(0);
+let i = 1;
+(function dfs(v) {
+	visited[v - 1] = i++;
+	for (let vertex of adjacencyList[v]) {
+		if (!visited[vertex - 1]) dfs(vertex);
+	}
+})(R);
+
+console.log(visited.join("\n"));


### PR DESCRIPTION
### 문제 설명&링크
* 문제 이름: ex) 백준 24480 <알고리즘 수업 - 깊이 우선 탐색 2> 
* 문제 링크: https://www.acmicpc.net/problem/24480

### 의사 코드
0. 각 정점이 인덱스가 되고 값은 인접 정점들을 배열로가진 2차원 배열 adjacencyList를 만든다.
1. 인접 정점 리스트 adjacencyList를 내림차순 정렬한다.
2. 방문할 정점을 표시할 배열 visited를 정점 수만큼 생성한다.
3. visited에 방문여부를 표시할 때 동시에 값으로 방문순서i를 표시해야 한다.
4. 깊이우선탐색 재귀함수를 만들어 시작정점부터 실행한다. 
	4.1. 아직 방문하지 않은 정점에 visited에 방문순서i를 증가시켜가며 표시하고,
	4.2. 해당 정점의 인접 정점을 순회하며 visited를 활용해 아직 방문하지 않는 정점에 함수를 실행한다. 
5. visited 배열을 알맞은 형태로 리턴한다.

### 코드
```js
let [info, ...input] = require("fs")
	.readFileSync("./dev/stdin")
	.toString()
	.trim()
	.split("\n")
	.map((el) => el.split(" ").map((el) => +el));
let [N, M, R] = info;

const adjacencyList = Array.from({ length: N + 1 }, (_) => []);
for (let el of input) {
	let [v1, v2] = el;
	adjacencyList[v1].push(v2);
	adjacencyList[v2].push(v1);
}
for (let i = 1; i < adjacencyList.length; i++) {
	adjacencyList[i].sort((a, b) => b - a);
}
const visited = Array(N).fill(0);
let i = 1;
(function dfs(v) {
	visited[v - 1] = i++;
	for (let vertex of adjacencyList[v]) {
		if (!visited[vertex - 1]) dfs(vertex);
	}
})(R);

console.log(visited.join("\n"));
```

### 느낀점&어려웠던 점
- 깊이 우선 탐색 공부하기에 좋은 문제입니다. 위의 코드는 물론 통과한 코드입니다.
- 그런데 이해가 안가는 점이 하나있어요! (제목은 미안합니다 이거 보여줄려고 어그로 끌었습니다 조만간 바꿀게요)
```js
const adjacencyList = Array.from({ length: N + 1 }, (_) => []);
```
- 위에서 이 부분에 `{length: N}`으로 배열 만들어도 전혀 문제없고 에러도 안나야 정상입니다. 그런데 백준에서는 
```js
const adjacencyList = Array.from({ length: N }, (_) => []);
```
이렇게 하면 런타임 에러(TypeError)가 나네요??? 대체 왜일까요? N과 N+1의 차이가 뭘까요??? 
계속 에러뜨고 통과안되서 이것때문인 줄도 모르고 3시간 정도 삽질했습니다... 아까운 나의 시간 ㅠㅠㅠㅠ
백준은 답을 알려달라...
다른 문제도 이런 런타임 에러 질문이 있던데 7년째 해결 안 된거 봤습니다... ㅠㅠㅠ 
