### PR TITLE
[7주차-동적계획법] 문제5 - 손수빈

### DIFF
--- a/7주차) 동적계획법/q05/merryfraise.js
+++ b/7주차) 동적계획법/q05/merryfraise.js
@@ -1,0 +1,46 @@
+/**
+ * BAEKJOON ONLINE JUDGE
+ * https://www.acmicpc.net/problem/1003
+ * Problem Number: 1003
+ * Level: Silver III
+ * Algorithm: 다이나믹 프로그래밍
+ */
+
+const [T, ...input] = require('fs')
+  .readFileSync('/dev/stdin')
+  .toString()
+  .trim()
+  .split('\n')
+  .map(Number);
+
+/* pseudocode
+   1. [0 카운트 횟수, 1 카운트 횟수]
+      1-1. N이 0이면 [1, 0]
+      1-2. N이 1이면 [0, 1]
+      1-3. N이 2 이상인 경우 이전의 두 카운트 수의 합 [1 + 0, 0 + 1]
+   2. N까지 N - 1, N - 2의 카운트를 계속 더해준다
+*/
+
+const result = [];
+
+const fibonacci = (N) => {
+  const fiboCount = [
+    [1, 0],
+    [0, 1],
+  ];
+
+  for (let i = 2; i <= N; i++) {
+    fiboCount[i] = [
+      fiboCount[i - 1][0] + fiboCount[i - 2][0],
+      fiboCount[i - 1][1] + fiboCount[i - 2][1],
+    ];
+  }
+
+  return fiboCount[N].join(' ');
+};
+
+for (const el of input) {
+  result.push(fibonacci(el));
+}
+
+console.log(result.join('\n'));


### PR DESCRIPTION
### 문제 설명&링크
* 문제 이름: 백준 silver3. <피보나치 함수> 
* 문제 링크: https://www.acmicpc.net/problem/1003

### 의사 코드
1. [0 카운트 횟수, 1 카운트 횟수]
   1-1. N이 0이면 [1, 0]
   1-2. N이 1이면 [0, 1]
   1-3. N이 2 이상인 경우 이전의 두 카운트 수의 합 [1 + 0, 0 + 1]
2. N까지 N - 1, N - 2의 카운트를 계속 더해준다

### 코드
```js
const [T, ...input] = require('fs')
  .readFileSync('/dev/stdin')
  .toString()
  .trim()
  .split('\n')
  .map(Number);

const result = [];

const fibonacci = (N) => {
  const fiboCount = [
    [1, 0],
    [0, 1],
  ];

  for (let i = 2; i <= N; i++) {
    fiboCount[i] = [
      fiboCount[i - 1][0] + fiboCount[i - 2][0],
      fiboCount[i - 1][1] + fiboCount[i - 2][1],
    ];
  }

  return fiboCount[N].join(' ');
};

for (const el of input) {
  result.push(fibonacci(el));
}

console.log(result.join('\n'));
```

### 느낀점&어려웠던 점
메모이제이션을 사용한 피보나치 DP 풀이입니다..
메모이제이션을 할 때 피보나치 수열의 수를 기억시킨 것이 아니라 0 카운트 횟수와 1 카운트 횟수를 기억시켜주었습니다.
`fibonacci(2) = fibonacci(1) + fibonacci(0)`,
`fibonacci(3) = fibonacci(2) + fibonacci(1)` ... 이기 때문에 이전에 나온 두 수에서 0과 1의 카운트 횟수를 더해주면 현재 숫자의 0과 1의 카운트 횟수가 나옵니다. (피보나치 기본 원리와 동일)