### PR TITLE
[7주차-동적계획법] 문제8 - 손수빈

### DIFF
--- a/7주차) 동적계획법/q08/merryfraise.js
+++ b/7주차) 동적계획법/q08/merryfraise.js
@@ -1,0 +1,35 @@
+/**
+ * BAEKJOON ONLINE JUDGE
+ * https://www.acmicpc.net/problem/14501
+ * Problem Number: 14501
+ * Level: Silver III
+ * Algorithm: 다이나믹 프로그래밍 / 브루트포스 알고리즘
+ */
+
+const [N, ...input] = require('fs')
+  .readFileSync('/dev/stdin')
+  .toString()
+  .trim()
+  .split('\n')
+  .map((el) => (el.includes(' ') ? el.split(' ').map(Number) : +el));
+
+/* pseudocode
+   0. https://kau-algorithm.tistory.com/800
+   1. 퇴사 이후까지 상담이 지속되면 패스
+   2. 이미 생긴 수익 + 해당일 상담을 진행했을 경우 얻는 수익을 저장
+   3. 해당일과 다른 상담을 진행할 경우 얻는 수익을 2번의 값과 비교하여 더 큰 값 저장
+*/
+
+const memo = Array(N).fill(0);
+
+for (let i = 0; i < N; i++) {
+  if (i + input[i][0] > N) continue;
+
+  memo[i] += input[i][1];
+
+  for (let j = i + input[i][0]; j < N; j++) {
+    memo[j] = Math.max(memo[j], memo[i]);
+  }
+}
+
+console.log(Math.max(...memo));


### PR DESCRIPTION
### 문제 설명&링크
* 문제 이름: 백준 silver3. <퇴사> 
* 문제 링크: https://www.acmicpc.net/problem/14501

### 의사 코드
0. https://kau-algorithm.tistory.com/800
1. 퇴사 이후까지 상담이 지속되면 패스
2. 이미 생긴 수익 + 해당일 상담을 진행했을 경우 얻는 수익을 저장
3. 해당일과 다른 상담을 진행할 경우 얻는 수익을 2번의 값과 비교하여 더 큰 값 저장

### 코드
```js
const [N, ...input] = require('fs')
  .readFileSync('/dev/stdin')
  .toString()
  .trim()
  .split('\n')
  .map((el) => (el.includes(' ') ? el.split(' ').map(Number) : +el));

const memo = Array(N).fill(0);

for (let i = 0; i < N; i++) {
  if (i + input[i][0] > N) continue;

  memo[i] += input[i][1];

  for (let j = i + input[i][0]; j < N; j++) {
    memo[j] = Math.max(memo[j], memo[i]);
  }
}

console.log(Math.max(...memo));
```

### 느낀점&어려웠던 점
문제 이름이 너무 강렬해서 풀었는데 개인적으로 DP 풀었던 3개 문제 중 가장 이해가 되지 않습니다 ㅎㅎ..
다른 분의 풀이를 보고 풀었어요....

그와 별개로 문제 자체도 조금 헷갈리게 낸 것 같습니다 ^^;
문제 내용에 따르면 N+1일 째에는 회사에 없기 때문에 N+1일이 포함되면 상담을 진행할 수 없다고 하는데, 예제 2번을 보면 10일에 하루 걸리는 상담을 더 진행할 수 있게 출력이 짜여져 있어요.

그리고 상담 진행을 저는 연속적으로 해야 한다고 생각했는데 상담 하나가 끝나면 그 이후 상담 중 날짜에 맞는 것 중 수익을 크게 얻을 수 있는 방향으로 정하면 됩니다 ㅠㅠ