### PR TITLE
[8주차-프로그래머스 Lv1] 문제12 - 손수빈

### DIFF
--- a/8주차) 프로그래머스 Lv1/q12/merryfraise.js
+++ b/8주차) 프로그래머스 Lv1/q12/merryfraise.js
@@ -1,0 +1,15 @@
+/**
+ * Programmers
+ * https://school.programmers.co.kr/learn/courses/30/lessons/86051
+ * Problem Number: 86051
+ * Level: 월간 코드 챌린지 시즌3
+ * Algorithm: 연습문제
+ */
+
+/* pseudocode
+   1. 0부터 9까지의 합인 45에서 존재하는 숫자들을 뺀다.
+*/
+
+function solution(numbers) {
+  return numbers.reduce((acc, cur) => (acc -= cur), 45);
+}


### PR DESCRIPTION
### 문제 설명&링크
* 문제 이름: 프로그래머스 lv1. <없는 숫자 더하기> 
* 문제 링크: https://school.programmers.co.kr/learn/courses/30/lessons/86051

### 의사 코드
1. 0부터 9까지의 합인 45에서 존재하는 숫자들을 뺀다.

### 코드
```js
function solution(numbers) {
  return numbers.reduce((acc, cur) => (acc -= cur), 45);
}
```

### 느낀점&어려웠던 점
앞선 PR에서 한 줄 짜리 가독성 구린 풀이가 싫다고 했지만..
이 문제는 보자마자 `reduce`라는 것밖에 생각이 나지 않았습니다.ㅋㅋㅋㅋ

초기값이 45인 이유는 `numbers`의 요소가 0부터 9까지이기 때문입니다. 0부터 9까지 모든 숫자를 더한 값에서 `numbers`의 요소들을 빼면 `numbers`에 존재하지 않는 숫자들의 합이 나옵니다.