### PR TITLE
[9주차-프로그래머스 Lv2] 문제7 - 김진주

### DIFF
--- a/9주차) 프로그래머스 Lv2/q07/jin123.js
+++ b/9주차) 프로그래머스 Lv2/q07/jin123.js
@@ -1,0 +1,32 @@
+function solution(n, info) {
+  let maxScoreDiff = 0;
+  let result = [-1];
+  const apeachTotalScore = info.reduce(
+    (acc, cur, i) => (cur && i < 10 ? acc + 10 - i : acc),
+    0
+  );
+
+  const dfs = (lion, index, arrowN, lionS, apeachS) => {
+    if (!arrowN || index === -1) {
+      if (maxScoreDiff < lionS - apeachS) {
+        maxScoreDiff = lionS - apeachS;
+        result = [...lion];
+        result[10] = arrowN;
+      }
+      return;
+    }
+    lion[index] = info[index] + 1;
+    if (arrowN - lion[index] >= 0)
+      dfs(
+        lion,
+        index - 1,
+        arrowN - lion[index],
+        lionS + 10 - index,
+        info[index] ? apeachS - 10 + index : apeachS
+      );
+    lion[index] = 0;
+    dfs(lion, index - 1, arrowN, lionS, apeachS);
+  };
+  dfs(Array(11).fill(0), 9, n, 0, apeachTotalScore);
+  return result;
+}


### PR DESCRIPTION
### 문제 설명&링크
* 문제 이름: 프로그래머스 lv2 < 양궁대회 > 
* 문제 링크: https://school.programmers.co.kr/learn/courses/30/lessons/92342

### 의사 코드

1. `maxScoreDiff`: 어피치와 라이언의 점수 차의 최댓값을 저장하는 변수
2. `result`: 어피치와 라이언의 점수 차가 최댓값일 때 각 점수별 라이언이 쏜 화살 개수를 저장하는 변수
3. `apeachTotalScore`: 라이언이 모두 0점을 쐈을 때 어피치의 점수 (어피치 점수의 최댓값)
4. 크기가 11인 빈 배열(라이언이 쏜 화살 정보를 저장할 배열),apeachTotalScore 로 dfs를 호출한다.
5. result를 반환한다.

**`dfs`**
- `lion`: lion이 쏜 화살 정보를 저장하는 배열
- `index`: 탐색 중인 인덱스 값 (인덱스는 과녁 점수를 의미, 인덱스0: 10점)
- `arrowN`: lion이 쏠 수 있는 화살 개수
- `lionS`: lion의 점수 합
- `apeachS`: apeach의 점수 합

1. arrowN이 0이거나 index가 -1인 경우 (라이언이 쏠 수 있는 화살을 모두 분배한 경우, 0점을 제외한 모든 과녁 점수에 화살 분배를 마친 경우)
    1. maxScoreDiff의 값보다 새롭게 탐색한 조합의 라이언과 어피치 점수 차가 더 클 경우
        1. maxScoreDiff를 새로운 값으로 갱신한다
        2. result를 현재 화살 정보값으로 갱신한다
        3. 남은 모든 화살을 0점(인덱스 10)에 쏘았다고 처리한다(arrowN이 0이었던 경우에는 어짜피 0이 할당되어 값에 영향이 없으므로 따로 조건문 처리를 하지 않았다)
    2. 함수 실행을 종료한다.
3. 현재 탐색 중인 과녁 배점에 대하여 라이언이 어피치보다 1발 더 많이 쐈다고 저장한다.
4. 라이언이 쏠 수 있는 총 화살 개수에서 2번에서 가정한 화살 개수를 뺐을 때 0보다 크거나 작다면
    1. `lion`,`index-1`,`arrowN-lion[index]`(남은 라이언이 쏠 수 있는 화살 개수), `lion+10-index`(라이언 점수에 현재 탐색 중인 과녁 배점을 더함),`info[index] ? apeachS - 10 + index : apeachS` (어피치가 해당 과녁 배점을 쏜 적이 있다면 합에서 빼줌)으로 dfs를 호출한다.
5. 현재 탐색 중인 과녁 배점에 대하여 라이언이 쏜 화살이 없다고 저장한다.
6. `lion`,`index-1`,`arrowN`(남은 라이언이 쏠 수 있는 화살 개수),`lionS`,`apeachS`(라이언과 어피치 합에 변함 없음)로 dfs를 호출한다.
***
**`고려해야하는 사항`**

1. 어피치가 a발을 맞혔고 라이언이 b발을 맞혔을 경우 더 많은 화살을 k점에 맞힌 선수가 k 점을 가져간다. 단, a = b일 경우는 어피치가 k점을 가져간다.
2. 최종 점수가 더 높은 선수를 우승자, 최종 점수가 같을 경우 어피치가 우승자
3. 라이언이 우승할 수 없는 경우(무조건 지거나 비기는 경우)는 `[-1]`을 return
4. 라이언이 가장 큰 점수 차이로 우승할 수 있는 방법이 여러 가지 일 경우, 가장 낮은 점수를 더 많이 맞힌 경우를 return
5. 라이언이 가장 큰 점수 차이로 우승하기 위해 n발의 화살을 어떤 과녁 점수에 맞혀야 하는지를 구한다.

- `apeachTotalScore`에 어피치 점수의 최댓값을 미리 구하는 이유는 dfs 내부에서 라이언이 쏠 수 있는 화살을 모두 배분하였고 index를 아직 전부 탐색하지 않은 경우마다 나머지 어피치 점수를 마저 계산해 줄 필요 없이 바로 `result`와 `maxScoreDiff`값을 구하기 위해서입니다.

-  4번을 위해서 탐색을 인덱스 9부터 합니다. 그리고 dfs호출을 라이언이 어피치보다 많이 화살을 쏘아서 해당 점수를 라이언이 가져가는 경우부터 합니다. 그렇게 되면 `maxScoreDiff`를 갱신할 때  `maxScoreDiff`값이 현재 탐색 값으로 얻은 라이언과 어피치 점수차가 같은 경우에는 갱신하지 않음으로써 가장 낮은 점수를 더 많이 맞힌 경우의 우선순위를 높여서 저장할 수 있습니다. 

-  라이언이 현재 탐색하는 과녁 점수에 화살을 쏘는 여러가지의 경우의 수를 1. 과녁 점수를 라이언이 가져가는 경우, 2. 가져가지 않는 경우로 나눌 수 있습니다. 라이언이 점수를 가져가는 경우는 최소한의 화살 개수로 점수를 얻어 가야 라이언 점수가 최대가 되므로 `어피치가 쏜 화살 수 +1`개를 쏜 경우만 탐색하면 됩니다. 라이언이 점수를 가져가지 않는 경우는 쏜 화살이 없어야 라이언의 점수가 최대가 되므로 `0개`를 쏜 경우만 탐색하면 됩니다. 

### 코드
```js
function solution(n, info) {
  let maxScoreDiff = 0;
  let result = [-1];
  const apeachTotalScore = info.reduce(
    (acc, cur, i) => (cur && i < 10 ? acc + 10 - i : acc),
    0
  );

  const dfs = (lion, index, arrowN, lionS, apeachS) => {
    if (!arrowN || index === -1) {
      if (maxScoreDiff < lionS - apeachS) {
        maxScoreDiff = lionS - apeachS;
        result = [...lion];
        result[10] = arrowN;
      }
      return;
    }
    lion[index] = info[index] + 1;
    if (arrowN - lion[index] >= 0)
      dfs(
        lion,
        index - 1,
        arrowN - lion[index],
        lionS + 10 - index,
        info[index] ? apeachS - 10 + index : apeachS
      );
    lion[index] = 0;
    dfs(lion, index - 1, arrowN, lionS, apeachS);
  };
  dfs(Array(11).fill(0), 9, n, 0, apeachTotalScore);
  return result;
}

```

### 느낀점&어려웠던 점
- 고려해야하는 사항 4번을 놓쳐서 테스트 케이스 8,18번을 계속 틀렸습니다. 어피치의(배열 info) 0이 아닌 마지막 값의 인덱스을 얻기 위해서 result에 저장되는 배열의 0이 아닌 마지막 값 인덱스를 저장하는 변수를 따로 두고 갱신하는 방법으로 풀었는데 index를 9부터 탐색하고 maxScoreDiff값이 같은 경우는 result, maxScoreDiff의 갱신을 고려하지 않는 방식이 코드가 훨씬 깔끔했습니다.
- dfs에서 lion 배열을 파라미터로 계속 넘겨주는 게 불필요해 보여서 외부에 아예 저장을 하고 그 값을 사용하도록 변경했었는데 실행 시간이 오히려 늘어났습니다! 그 이유는 closure가 생성되면서 스코프 체인에서 lion을 찾는 과정이 필요하게 되어서 발생하는 것이라고 합니다. 
