### PR TITLE
[9주차-프로그래머스 Lv2] 문제3 - 이희진

### DIFF
--- a/9주차) 프로그래머스 Lv2/q03/9lumint.js
+++ b/9주차) 프로그래머스 Lv2/q03/9lumint.js
@@ -1,0 +1,20 @@
+function sum(arr) {
+  return arr.reduce((a, c) => a + c);
+}
+
+function solution(queue1, queue2) {
+  let sum1 = sum(queue1),
+      sum2 = sum(queue2),
+      target = (sum1 + sum2) / 2,
+      pointer1 = 0,
+      pointer2 = queue1.length,
+      queue = [...queue1, ...queue2];
+
+  for (let count = 0; count < queue1.length * 3; count++) {
+    if (sum1 === target) {
+      return count;
+    }
+    sum1 > target ? (sum1 -= queue[pointer1++]) : (sum1 += queue[pointer2++]);
+  }
+  return -1;
+}


### PR DESCRIPTION
### 문제 설명&링크
* 문제 이름: 프로그래머스 lv2 < 두 큐 합 같게 만들기 >
* 문제 링크: https://school.programmers.co.kr/learn/courses/30/lessons/118667

### 의사 코드
1. 기준점이 되는 두 큐의 합의 평균을 구한다(target).
2. 두 큐를 합한 queue를 생성하고 첫 번째 포인터(시작점)는 0, 두 번째 포인터는 queue1.length(이는 두 번째 큐의 0 번째 인덱스 자리와 같음)로 설정해 할당한다.
3. 각 포인터는 곧 각 큐의 시작점과 같다. 즉, 시작점을 옮긴다는 건 한 요소에 대해 shift와 push가 발생했다는 의미가 되므로 count가 1씩 증가한다. 또한 count는 각 요소가 움직일 수 있는 범위를 뜻하며 첫 번째 포인터가 움직일 수 있는 범위인 queue1.length * 2 (queue1의 처음부터 queue2의 끝까지 가능하므로)와 두 번째 포인터가 움직일 수 있는 범위인 queue2.length를 더한 총 queue1.length * 3가 된다.
4. queue1의 총합이 target과 일치하면 queue2의 총합 역시 자연히 일치하므로 queue1의 총합(sum1)의 범위를 조절하며 포인터를 이동시킨다.
4-1. 만약 sum1이 목표보다 작을 경우 더 많은 요소가 필요하므로 pointer2을 이동시켜 queue1의 범위를 넓힌다.
4-2. 만약 sum2이 목표보다 클 경우 요소를 덜어내야 하므로 pointer1를 이동시켜 queue1의 범위를 좁힌다.
5. 4의 과정을 반복하면서 만약 목표와 일치할 경우 그 즉시 count를 반환한다.
6. 이동 횟수를 전부 소진할 때까지 목표와 일치하지 못할 경우 -1을 반환한다.

### 코드
```js
function sum(arr) {
  return arr.reduce((a, c) => a + c);
}

function solution(queue1, queue2) {
  let sum1 = sum(queue1),
      sum2 = sum(queue2),
      target = (sum1 + sum2) / 2,
      pointer1 = 0,
      pointer2 = queue1.length,
      queue = [...queue1, ...queue2];

  for (let count = 0; count < queue1.length * 3; count++) {
    if (sum1 === target) {
      return count;
    }
    sum1 > target ? (sum1 -= queue[pointer1++]) : (sum1 += queue[pointer2++]);
  }
  return -1;
}
```

### 느낀점&어려웠던 점
역시 카카오 ^^ 혼자 힘으로는 도저히 해낼 수 없어서 천재분들의 코드를 많이 참고했습니다. 그 과정에서 투 포인터라는 풀이법에 대해서 배울 수 있었습니다. 이진 탐색과 흐름 자체는 비슷하지만 이진 탐색은 정렬이 필수지만 투 포인터는 그렇지 않다는 차이점도 존재합니다. 이런 합을 구한다던가 할 때 아무래도 앞자리가 뒷자리보다 작거나 커야 할 필요는 없긴 하죠! 더 많은 공부가 필요하다는 걸 느꼈습니다. 해당 개념에 대한 설명은 유튜브에 많습니다! 제가 참고했던 링크도 하나 첨부해 드리겠습니다. 
https://www.youtube.com/watch?v=iSjvuixMPmQ