### PR TITLE
[10주차-프로그래머스 Lv3] 문제8 - 신나현

### DIFF
--- a/10주차) 프로그래머스 Lv3/q08/shinnh2.js
+++ b/10주차) 프로그래머스 Lv3/q08/shinnh2.js
@@ -1,0 +1,38 @@
+//의사코드
+/*
+1. enroll개수만큼 수익 기록장부 result를 만든다.
+2. seller를 순회하며 각 i번째 요소를 확인한다.
+    2.1. amount의 i번째 * 칫솔금액 100을 곱해서 총 판매량을 계산한다.
+    2.2. enroll과 referral을 참고하여 추천인이 없을 때까지 수익을 계산한다.
+3. x의 수익 계산하기 (판매수익 n): 
+참고: 효율성을 위해 한 번 확인한 사람의 인덱스는 확인하지 않도록 확인할 enroll의 범위를 줄여준다.
+    3.1. enroll에서 x를 찾아 인덱스 nowIdx를 기억한다.
+    3.2. referral[nowIdx]가 "-"라면: result[nowIdx]에 판매수익 n-(n*0.1)을 더하고 끝낸다.  
+    3.2. referral[nowIdx]가 "-"가 아니라면: 
+        - n*0.1이 1미만이라면 result[now]에 판매수익 n을 더하고 끝낸다.
+        - 아니라면 result[nowIdx]에 판매수익 n-(n*0.1)을 더한다.
+    3.4. referral[now]와 판매수익 n*0.1로 3번 과정을 반복한다.
+4. result를 리턴한다.
+*/
+
+function solution(enroll, referral, seller, amount) {
+	let result = Array(enroll.length).fill(0);
+	const calc = (arr, person, n) => {
+		let nowIdx = arr.lastIndexOf(person);
+		if (referral[nowIdx] === "-") {
+			result[nowIdx] += n - Math.floor(n * 0.1);
+			return;
+		} else {
+			if (Math.floor(n * 0.1) < 1) {
+				result[nowIdx] += n;
+				return;
+			}
+			result[nowIdx] += n - Math.floor(n * 0.1);
+		}
+		calc(arr.slice(0, nowIdx), referral[nowIdx], Math.floor(n * 0.1));
+	};
+	for (let i = 0; i < seller.length; i++) {
+		calc(enroll, seller[i], amount[i] * 100);
+	}
+	return result;
+}


### PR DESCRIPTION
### 문제 설명&링크
* 문제 이름: 프로그래머스 lv3. <다단계 칫솔 판매> 
* 문제 링크: https://school.programmers.co.kr/learn/courses/30/lessons/77486

### 의사 코드
1. enroll개수만큼 수익 기록장부 result를 만든다.
2. seller를 순회하며 각 i번째 요소를 확인한다.
    2.1. amount의 i번째 * 칫솔금액 100을 곱해서 총 판매량을 계산한다.
    2.2. enroll과 referral을 참고하여 추천인이 없을 때까지 수익을 계산한다.
3. x의 수익 계산하기 (판매수익 n): 
참고: 효율성을 위해 한 번 확인한 사람의 인덱스는 확인하지 않도록 확인할 enroll의 범위를 줄여준다.
    3.1. enroll에서 x를 찾아 인덱스 nowIdx를 기억한다.
    3.2. referral[nowIdx]가 "-"라면: result[nowIdx]에 판매수익 n-(n*0.1)을 더하고 끝낸다.  
    3.2. referral[nowIdx]가 "-"가 아니라면: 
        - n*0.1이 1미만이라면 result[now]에 판매수익 n을 더하고 끝낸다.
        - 아니라면 result[nowIdx]에 판매수익 n-(n*0.1)을 더한다.
    3.4. referral[now]와 판매수익 n*0.1로 3번 과정을 반복한다.
4. result를 리턴한다.

### 코드
```js
function solution(enroll, referral, seller, amount) {
    let result=Array(enroll.length).fill(0);
    const calc=(arr, person, n)=>{
        let nowIdx=arr.lastIndexOf(person);
        if(referral[nowIdx]==="-"){
            result[nowIdx]+=n-Math.floor(n*0.1);
            return;
        }else{
            if(Math.floor(n*0.1)<1){
                result[nowIdx]+=n;
                return;
            }
            result[nowIdx]+=n-Math.floor(n*0.1);
        }
        calc(arr.slice(0, nowIdx), referral[nowIdx], Math.floor(n*0.1));
    }    
    for(let i=0; i<seller.length; i++){
        calc(enroll, seller[i], amount[i]*100);
    }
    return result;
}
```

### 느낀점&어려웠던 점
- 제 스스로 다시 풀어보았습니다. 의사코드와 풀이가 라이브 때 발표했던 것이랑 다르므로 혹시 라이브의 풀이가 궁금하다면 다음의 링크를 참고하시기 바랍니다!
https://velog.io/@tnehd1998/%ED%94%84%EB%A1%9C%EA%B7%B8%EB%9E%98%EB%A8%B8%EC%8A%A4-%EB%8B%A4%EB%8B%A8%EA%B3%84-%EC%B9%AB%EC%86%94-%ED%8C%90%EB%A7%A4-JavaScript 
- 재귀가 안된다는 분들도 있는데, 저는 좀 느린것 같아보여도 재귀를 사용해서 통과하였습니다. 
- 조건문을 좀 더 깔끔하게 써보고 싶었는데 그렇지 않게 되었네요...ㅎㅎ 시간이 된다면 좀 더 리팩토링 해보도록 하겠습니다!